### PR TITLE
webui: Fix OIDC login Sign In disabled by always-required credentials

### DIFF
--- a/webui/src/app/login-screen/login-screen.component.html
+++ b/webui/src/app/login-screen/login-screen.component.html
@@ -95,7 +95,7 @@
                         <div>
                             @if (nonFormAuth()) {
                                 <a
-                                    href="oidc/login?returnUrl={{ returnUrl }}"
+                                    href="/oidc/login?returnUrl={{ returnUrl }}"
                                     pButton
                                     class="w-full no-underline"
                                     [loading]="nonFormAuthSubmitted()"

--- a/webui/src/app/login-screen/login-screen.component.spec.ts
+++ b/webui/src/app/login-screen/login-screen.component.spec.ts
@@ -195,4 +195,79 @@ describe('LoginScreenComponent', () => {
             })
         )
     })
+
+    it('should enable OIDC when it is the only authentication method', fakeAsync(() => {
+        // Regression: with a single method there is no Select onChange, so non-form
+        // state must be applied during method load.
+        const authService = fixture.debugElement.injector.get(AuthService)
+        spyOn(authService, 'getAuthenticationMethods').and.returnValue(
+            of([
+                {
+                    description:
+                        'OAuth2/OIDC authentication. You will get redirected to OpenID Provider to authenticate and authorize your access to Stork.',
+                    id: 'oidc',
+                    name: 'Log in with OpenID Connect',
+                },
+            ] as AuthenticationMethod[])
+        )
+
+        component.ngOnInit()
+        tick()
+        fixture.detectChanges()
+
+        expect(component.nonFormAuth()).toBeTrue()
+        expect(component.loginForm.valid).toBeTrue()
+
+        const oidcLink = fixture.debugElement.query(By.css('.login-screen__authentication-inputs a'))
+        expect(oidcLink).toBeTruthy()
+        expect(oidcLink.nativeElement.getAttribute('href')).toContain('/oidc/login?returnUrl=')
+    }))
+
+    it('should restore OIDC preference from localStorage on init', fakeAsync(() => {
+        localStorage.setItem('selected-auth-method', 'oidc')
+
+        component.ngOnInit()
+        tick()
+        fixture.detectChanges()
+
+        expect(component.authenticationMethod.id).toEqual('oidc')
+        expect(component.nonFormAuth()).toBeTrue()
+        expect(component.loginForm.valid).toBeTrue()
+        expect(component.loginForm.controls.identifier.hasError('required')).toBeFalse()
+        expect(component.loginForm.controls.secret.hasError('required')).toBeFalse()
+    }))
+
+    it('should enable non-form OIDC login with absolute path', fakeAsync(() => {
+        component.ngOnInit()
+        tick()
+        fixture.detectChanges()
+
+        const dropdown = fixture.debugElement.query(By.css('.login-screen__authentication-selector .p-select'))
+        dropdown.nativeElement.click()
+        fixture.detectChanges()
+
+        const listItems = dropdown.queryAll(By.css('.p-select-list li'))
+        listItems[2].nativeElement.click()
+        tick()
+        fixture.detectChanges()
+
+        expect(component.nonFormAuth()).toBeTrue()
+        expect(component.loginForm.valid).toBeTrue()
+
+        const oidcLink = fixture.debugElement.query(By.css('.login-screen__authentication-inputs a'))
+        expect(oidcLink).toBeTruthy()
+        expect(oidcLink.nativeElement.getAttribute('href')).toContain('/oidc/login?returnUrl=')
+
+        // Switching back to a form method re-applies required credential validators.
+        dropdown.nativeElement.click()
+        fixture.detectChanges()
+        const formMethodItems = dropdown.queryAll(By.css('.p-select-list li'))
+        formMethodItems[0].nativeElement.click()
+        tick()
+        fixture.detectChanges()
+
+        expect(component.nonFormAuth()).toBeFalse()
+        expect(component.loginForm.controls.identifier.hasError('required')).toBeTrue()
+        expect(component.loginForm.controls.secret.hasError('required')).toBeTrue()
+    }))
 })

--- a/webui/src/app/login-screen/login-screen.component.ts
+++ b/webui/src/app/login-screen/login-screen.component.ts
@@ -194,9 +194,11 @@ export class LoginScreenComponent implements OnInit {
                 const index = methods.findIndex((m) => m.id === storedMethod)
                 if (index > -1) {
                     this.authenticationMethod = methods[index]
-                    this.updateNonFormLabel(this.authenticationMethod)
                 }
             }
+            // Always refresh non-form UI state and credential validators for the
+            // selected method (including OIDC-only and restored OIDC preference).
+            this.updateNonFormLabel(this.authenticationMethod)
             this.loginForm.controls.authenticationMethod.setValue(this.authenticationMethod)
         })
     }
@@ -294,6 +296,15 @@ export class LoginScreenComponent implements OnInit {
         this.nonFormAuth.set(id === 'oidc')
         if (this.nonFormAuth()) {
             this.nonFormButtonLabel.set(authMethod.name)
+            // OIDC has no identifier/secret fields; drop required validators so
+            // the form is not permanently invalid for non-form methods.
+            this.loginForm.controls.identifier.clearValidators()
+            this.loginForm.controls.secret.clearValidators()
+        } else {
+            this.loginForm.controls.identifier.setValidators(Validators.required)
+            this.loginForm.controls.secret.setValidators(Validators.required)
         }
+        this.loginForm.controls.identifier.updateValueAndValidity()
+        this.loginForm.controls.secret.updateValueAndValidity()
     }
 }


### PR DESCRIPTION
## Context

Tried to utilize OIDC for authentication (Authentik as the IdP) but hit an issue that the login button could not be clicked after OIDC was chosen. Backend OIDC was fine (`GET /oidc/login` returned 302 to the IdP with correct `redirect_uri` / PKCE); the problem was only in the login UI.

I could not open an issue on GitLab (account signup blocked), so this is a GitHub PR as described in CONTRIBUTING.md for that case.

**Disclosure:** This fix was implemented with [Grok](https://x.ai/grok) (xAI). I (Tomi) have not carefully reviewed the change line-by-line myself; I verified that applying the equivalent fix unblocked OIDC login for me in a real deploy (Stork 2.5.0 + Authentik). Please treat the patch as needing a normal maintainer review.

## Summary

When OIDC is selected as the authentication method, the login form still keeps `identifier` / `secret` as **required**, so the form stays invalid. Combined with non-form UI state only being refreshed from the Select `onChange` path (not always on method load), OIDC is easy to leave unusable—especially with a single OIDC method or a restored OIDC preference.

Also fixes the OIDC link using a **relative** `oidc/login?…` href (no leading `/`), which is fragile behind reverse proxies / path resolution.

## Changes

- Always call `updateNonFormLabel()` for the selected method after methods load (OIDC-only and restored preference included).
- Clear required validators on identifier/secret for OIDC; restore them for form methods (local/LDAP).
- Use absolute path `/oidc/login?returnUrl=…` for the non-form login link.
- Unit tests: OIDC-only method list, localStorage restore of OIDC, select OIDC (absolute href + valid form) and switch back to local (required validators return).

## Test plan

- [ ] With local + OIDC methods: select OIDC → non-form button visible and clickable; form valid without username/password.
- [ ] Click OIDC button → browser navigates to `/oidc/login?returnUrl=…` → IdP (e.g. Authentik).
- [ ] Select local/LDAP again → identifier/secret required; Sign In disabled until filled.
- [ ] OIDC as sole method: non-form UI enabled on first load (no Select change needed).
- [ ] Restore `selected-auth-method=oidc` from localStorage → same as selecting OIDC.
- [ ] Existing local/LDAP sign-in still works.
- [ ] Unit tests for `login-screen.component.spec.ts`.

## Environment where this was observed

- Stork server **2.5.0**
- OIDC IdP: Authentik
- UI behind reverse proxy

## Notes

- GitLab issues are disabled for new signup in my case; happy to open/link a GitLab issue if someone grants access or files one for this.
- Related closed work (OIDC feature itself, not this UX bug): GitLab #2480, #2465.